### PR TITLE
fix nonworking testnet explorer

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -52908,8 +52908,8 @@ var ZWallet = function (_React$Component11) {
       _settings.useTestNet = !_settings.useTestNet;
 
       if (_settings.useTestNet) {
-        _settings.insightAPI = 'https://aayanl.tech/insight-api-zen/';
-        _settings.explorerURL = 'https://aayanl.tech/';
+        _settings.insightAPI = 'https://explorer-testnet.zen-solutions.io/insight-api-zen/';
+        _settings.explorerURL = 'https://explorer-testnet.zen-solutions.io/';
       } else {
         _settings.insightAPI = 'https://explorer.zensystem.io/insight-api-zen/';
         _settings.explorerURL = 'https://explorer.zensystem.io/';


### PR DESCRIPTION
After enabling testnet and putting in a private key into the web wallet, you get the following error:

```
Error connecting to the Insight API. Double check the Insight API supplied in settings.
```

Following links to the addresses leads you to a page with a broken SSL cert and non functioning explorer.

Example:
https://aayanl.tech/address/ztqnSNXKwCvCffSZFfYhVHpC1hVzLieN3Kh